### PR TITLE
Fixed error in MongoDB where it will throw an exception while mapping…

### DIFF
--- a/src/Helpfulcore.AnalyticsIndexBuilder/Data/ContactIdentifiers.cs
+++ b/src/Helpfulcore.AnalyticsIndexBuilder/Data/ContactIdentifiers.cs
@@ -1,8 +1,10 @@
 ﻿namespace Helpfulcore.AnalyticsIndexBuilder.Data
 {
     using System;
+    using MongoDB.Bson.Serialization.Attributes;
 
     [Serializable]
+    [BsonIgnoreExtraElements]
     public class ContactIdentifiers
     {
         public virtual bool IsEmpty { get; set; }

--- a/src/Helpfulcore.AnalyticsIndexBuilder/Data/ContactIdentifiersData.cs
+++ b/src/Helpfulcore.AnalyticsIndexBuilder/Data/ContactIdentifiersData.cs
@@ -1,7 +1,9 @@
 ﻿namespace Helpfulcore.AnalyticsIndexBuilder.Data
 {
     using System;
+    using MongoDB.Bson.Serialization.Attributes;
 
+    [BsonIgnoreExtraElements]
     [Serializable]
     public class ContactIdentifiersData
     {


### PR DESCRIPTION
When i run your tool on Sitecore 8.1.3 it will throw an exception that it can't map the Mongo record to the C# class. This is due to some extra properties in the Mongo record.

The added attribute in this commit will tell Mongo to ignore properties on the record that cannot be mapped.